### PR TITLE
Allow uncommented "wgsl" as a tag as well

### DIFF
--- a/syntaxes/wgsl-literal.json
+++ b/syntaxes/wgsl-literal.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:source -comment -string",
   "patterns": [
     {
-      "begin": "(?i)(\\s?\\/\\*\\s?(wgsl)\\s?\\*\\/\\s?)(`)",
+      "begin": "(?i)(wgsl|\\s?\\/\\*\\s?(wgsl)\\s?\\*\\/\\s?)(`)",
       "beginCaptures": {
         "1": {
           "patterns": [


### PR DESCRIPTION
Allows the syntax highlighting to continue working when using libraries like https://www.npmjs.com/package/wgsl-preprocessor which use "wgsl" as the tag.